### PR TITLE
fix fixBBoxes() bug

### DIFF
--- a/scripts/cnn_wsddn_test.m
+++ b/scripts/cnn_wsddn_test.m
@@ -6,7 +6,7 @@ function aps = cnn_wsddn_test(varargin)
 
 addpath('layers');
 addpath('pascal');
-addpath(fullfile('Layers','matlab'));
+addpath(fullfile('layers','matlab'));
 run(fullfile('matconvnet', 'matlab', 'vl_setupnn.m')) ;
 addpath(fullfile('matconvnet','examples'));
 
@@ -200,6 +200,7 @@ for i=1:numel(imdb.images.name)
   end
   
   if isfield(imdb.images,'boxScores')
+    imdb.images.boxScores{i} = imdb.images.boxScores{i}(isGood);
     imdb.images.boxScores{i} = imdb.images.boxScores{i}(uniqueIdx);
     imdb.images.boxScores{i} = imdb.images.boxScores{i}(1:nB);
   end

--- a/scripts/cnn_wsddn_train.m
+++ b/scripts/cnn_wsddn_train.m
@@ -189,6 +189,7 @@ for i=1:numel(imdb.images.name)
   end
   
   if isfield(imdb.images,'boxScores')
+    imdb.images.boxScores{i} = imdb.images.boxScores{i}(isGood);
     imdb.images.boxScores{i} = imdb.images.boxScores{i}(uniqueIdx);
     imdb.images.boxScores{i} = imdb.images.boxScores{i}(1:nB);
   end


### PR DESCRIPTION
This PR fixes a little bug in `scripts/cnn_wsddn_train.m` and `scripts/cnn_wsddn_test.m`.

Function `fixBBoxes()` removes small bounding box proposals, but it doesn't remove corresponding `boxScores` from EdgeBox. This may lead to mismatch between boxes and their score.
